### PR TITLE
[FIX] resolve module path to package.json file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ cache:
 notifications:
   email: false
 node_js:
+  - '12'
   - '10'
-  - '9'
   - '8'
 script:
   - npm run lint

--- a/src/cli.js
+++ b/src/cli.js
@@ -4,7 +4,7 @@ const { tryPackage, TryPackageError } = require('./index');
 const log = require('loglevel');
 
 const program = require('commander');
-const packageJSON = require('./package.json');
+const packageJSON = require('../package.json');
 
 // Setup the CLI options
 program


### PR DESCRIPTION
## Error message
```
Error: Cannot find module './package.json'
Require stack:
- /workspace/try/src/cli.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:772:15)
    at Function.Module._load (internal/modules/cjs/loader.js:677:27)
    at Module.require (internal/modules/cjs/loader.js:830:19)
    at require (internal/modules/cjs/helpers.js:68:18)
    at Object.<anonymous> (/workspace/try/src/cli.js:7:21)
    at Module._compile (internal/modules/cjs/loader.js:936:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:947:10)
    at Module.load (internal/modules/cjs/loader.js:790:32)
    at Function.Module._load (internal/modules/cjs/loader.js:703:12)
    at Function.Module.runMain (internal/modules/cjs/loader.js:999:10) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/workspace/try/src/cli.js' ]
}
```

System: MacOS X Mojave
Shell: Bash 5.0.11(1)-release
Node version: 12

## Remediation
`package.json` file exists one directory up, change require path