### PR TITLE
feat(): Add typescript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,18 @@ You can print the usage by executing `try --help`.
 
 ```shell
 
-Usage: try [packages]
+Usage: try [options]
 
 Quickly try out npm packages inside a container
 
 Options:
   -V, --version              output the version number
   -v, --verbose              Verbosity value
-  -i, --image [image]        The docker image which it should pull from [node] (default: "node")
-  --image-version [version]  Specify the node image version [latest] (default: "latest")
+  -i, --image [image]        The docker image which it should pull from (default: "node")
+  --image-version [version]  Specify the node image version (default: "latest")
+  --no-cleanup               If set to true, the created container will not get cleaned up
   --silent                   If the program should not print any log statements
+  --ts                       If it the program should use TypeScript
   -h, --help                 output usage information
 
 ```
@@ -64,7 +66,7 @@ install the dependencies using `npm` and execute the program.
 git clone https://github.com/BrunnerLivio/try.git
 cd try
 npm install
-node src/cli.js
+npm start
 
 ```
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -10,11 +10,13 @@ const packageJSON = require('../package.json');
 program
     .description(packageJSON.description)
     .version(packageJSON.version)
+    .name('try')
     .option('-v, --verbose', 'Verbosity value', (_, total) => total + 1, 0)
     .option('-i, --image [image]', 'The docker image which it should pull from', 'node')
     .option('--image-version [version]', 'Specify the node image version', 'latest')
     .option('--no-cleanup', 'If set to true, the created container will not get cleaned up', false)
     .option('--silent', 'If the program should not print any log statements')
+    .option('--ts', 'If it the program should use TypeScript', false)
     .parse(process.argv)
 
 const packages = program.args;
@@ -39,7 +41,8 @@ async function main () {
             version: program.imageVersion,
             image: program.image,
             verbose: program.silent ? 5 : verbose,
-            noCleanup: !program.cleanup
+            noCleanup: !program.cleanup,
+            useTypescript: program.ts
         });
         process.exit(0);
     } catch(err) {

--- a/src/docker-manager.js
+++ b/src/docker-manager.js
@@ -101,18 +101,29 @@ module.exports = class DockerManager {
     /**
      * Creates the container with an unique id
      */
-    async createContainer() {
+    async createContainer(useTypescript = false) {
+        let Cmd = ['node'];
+        if (useTypescript) {
+          const typeScriptPackages = 'ts-node typescript';
+          const tsNodePath = './node_modules/.bin/ts-node';
+          Cmd = ['/bin/bash', '-c', `yarn add global ${typeScriptPackages} && ${tsNodePath}`];
+        }
         this.containerName = this._generateContainerName();
         log.debug(`=> Creating container ${this.containerName}`);
         this.container = await this.docker.createContainer({ 
             Image: this.imageName,
-            Cmd: ['node'],
             name: this.containerName,
+            Cmd,
             Tty: true,
+            WorkingDir: '/usr/node',
             OpenStdin: true });
         log.debug('=> Starting container');
         await this.container.start();
         return this.containerName;
+    }
+
+    async updateCmd(Cmd) {
+      return this.container.update({ Cmd });
     }
 
     /**


### PR DESCRIPTION
Add TypeScript support. Executes `ts-node` instead of `node` in the container.

```bash
try express --ts
```
