### PR TITLE
feat(): add progress bar for `docker.pull`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1017,8 +1017,7 @@
     "ansi-escapes": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
-      "dev": true
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
     },
     "ansi-regex": {
       "version": "3.0.0",
@@ -1030,7 +1029,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -2249,7 +2247,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true,
       "requires": {
         "restore-cursor": "^2.0.0"
       }
@@ -2342,7 +2339,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -2350,8 +2346,12 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "colorette": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.1.0.tgz",
+      "integrity": "sha512-6S062WDQUXi6hOfkO/sBPVwE5ASXY4G2+b4atvhJfSsuUUhIaUKlkjLe9692Ipyt5/a+IPF5aVTu3V5gvXq5cg=="
     },
     "colors": {
       "version": "1.0.3",
@@ -2934,8 +2934,7 @@
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
     },
     "encoding": {
       "version": "0.1.12",
@@ -4240,8 +4239,7 @@
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-glob": {
       "version": "4.0.1",
@@ -4622,6 +4620,16 @@
       "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
       "dev": true
     },
+    "log-update": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-3.3.0.tgz",
+      "integrity": "sha512-YSKm5n+YjZoGZT5lfmOqasVH1fIH9xQA9A81Y48nZ99PxAP62vdCCtua+Gcu6oTn0nqtZd/LwRV+Vflo53ZDWA==",
+      "requires": {
+        "ansi-escapes": "^3.2.0",
+        "cli-cursor": "^2.1.0",
+        "wrap-ansi": "^5.0.0"
+      }
+    },
     "loglevel": {
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.4.tgz",
@@ -4796,8 +4804,7 @@
     "mimic-fn": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-      "dev": true
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -8586,7 +8593,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true,
       "requires": {
         "mimic-fn": "^1.0.0"
       }
@@ -9326,7 +9332,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true,
       "requires": {
         "onetime": "^2.0.0",
         "signal-exit": "^3.0.2"
@@ -9669,8 +9674,7 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "signale": {
       "version": "1.4.0",
@@ -10538,7 +10542,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.0",
         "string-width": "^3.0.0",
@@ -10548,14 +10551,12 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -10566,7 +10567,6 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8981,7 +8981,8 @@
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
     },
     "promise-inflight": {
       "version": "1.0.1",
@@ -9400,6 +9401,7 @@
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.3.tgz",
       "integrity": "sha512-wuYsAYYFdWTAnAaPoKGNhfpWwKZbJW+HgAJ+mImp+Epl7BG8oNWBCTyRM8gba9k4lk8BgWdoYm21Mo/RYhhbgA==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -10275,7 +10277,8 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -38,8 +38,10 @@
   },
   "dependencies": {
     "cli-spinner": "0.2.10",
+    "colorette": "^1.1.0",
     "commander": "3.0.2",
     "dockerode": "3.0.2",
+    "log-update": "^3.3.0",
     "loglevel": "1.6.4",
     "node-emoji": "1.10.0",
     "progress": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,6 @@
     "log-update": "^3.3.0",
     "loglevel": "1.6.4",
     "node-emoji": "1.10.0",
-    "progress": "2.0.3",
-    "rxjs": "6.5.3",
     "uuid": "3.3.3"
   },
   "devDependencies": {

--- a/src/pull-progress-indicator.js
+++ b/src/pull-progress-indicator.js
@@ -1,0 +1,103 @@
+const logUpdate = require('log-update');
+const { green, cyan, yellow } = require('colorette');
+const emoji = require('node-emoji');
+
+/**
+ * Some status names are long; this map has shorter names!
+ */
+const SHORT_NAME_STATUS = {
+    'pulling fs layer': 'Preparing',
+    'download complete': 'Downloaded',
+    'pull complete': 'Completed',
+    'retry': 'Retrying'
+};
+
+/**
+ * Maximum column length for status 
+ */
+const STATUS_STRING_MAX_LENGTH = 25;
+
+/**
+ * Cached emoji, so it needn't be fetched repeatedly!
+ */
+const PACKAGE_EMOJI = emoji.get('package');
+
+
+/**
+ * Starts up a progress bar for the `docker pull` operation, parses the event stream from dockerode to get the progress info.
+ */
+class PullProgressIndicator {
+    constructor() {
+        this._chunkInfo = null;
+    }
+
+    /**
+     * Gets shortened status name, because some status names can be a wee bit long.
+     * 
+     * @param {string} status 
+     */
+    _getShortenedStatus(status) {
+        if (!status) return '';
+
+        // Special case for retries
+        if (status.includes('retry')) return SHORT_NAME_STATUS.retry;
+
+        return SHORT_NAME_STATUS[status.toLowerCase()] || status;
+    }
+
+    /**
+     * Uses `log-update` to update the progress information on the terminal
+     */
+    _redrawProgress() {
+        if (this._chunkInfo === null) {
+            // TODO: Should we persist this? https://www.npmjs.com/package/log-update#logupdatedone
+            return logUpdate.clear();
+        }
+
+        const chunkProgress = Object.keys(this._chunkInfo).map(id => {
+            const { status, progress } = this._chunkInfo[id];
+            const chunkPart = `${PACKAGE_EMOJI} ${yellow(id)}`;
+
+            // Padding because even columns are <3 
+            const statusPart = green(this._getShortenedStatus(status).padEnd(STATUS_STRING_MAX_LENGTH));
+
+            const progressBarPart = cyan(progress || '');
+
+            return `${chunkPart} | ${statusPart} | ${progressBarPart}`;
+        })
+        .join(`\n`);
+
+        return logUpdate(chunkProgress);
+
+    }
+
+    /**
+     * Updates status, given an event from dockerode 
+     * 
+     * @param {Object} event
+     * @param {String} event.status 
+     * @param {String} [event.id=undefined]
+     * @param {Object} [event.progressDetail=undefined]
+     * @param {Object} [event.progress=undefined]
+     */
+    update(event) {
+        const { progressDetail, status, progress, id } = event || {};
+        if (!progressDetail) return;
+
+        // First time chunks are being encountered..
+        if (!this._chunkInfo) this._chunkInfo = {};
+
+        this._chunkInfo[id] = { progressDetail, status, progress };
+        this._redrawProgress();
+    }
+
+    /**
+     * Stops the progress bar and clears the terminal
+     */
+    stop() {
+        this._chunkInfo = null;
+        this._redrawProgress();
+    }
+}
+
+module.exports = PullProgressIndicator;

--- a/src/spinner.js
+++ b/src/spinner.js
@@ -17,6 +17,7 @@ function start({verbosity = 2, message = 'Setting up environment'} = {}) {
 
 function stop() {
     spinner && spinner.stop(true);
+    spinner = null;
 }
 
 function update(message) {


### PR DESCRIPTION
Fixes #3.

* Setup new `PullProgressIndicator` utility.
* Use dockerode's `followProgress#onProgress` callback to log progress. Dockerode makes it very easy to get the progress information; they even give out an ASCII progress bar  :O
* Add `log-update` package to overwrite log info
* Add `colorette` package for snazzy colors!

![progress-bar](https://user-images.githubusercontent.com/4935809/66723464-689f2800-ede7-11e9-8f80-279c69b3bf36.gif)
